### PR TITLE
Fix GitHub CODEOWNERS team recognition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @headstart-eng
+* @HeadstartAI/headstart-eng


### PR DESCRIPTION
## Description
This PR fixes the issue with GitHub not recognizing the headstart-eng team as a code owner.

## Changes
- Updated the CODEOWNERS file to use the correct syntax for team references
- Changed from  to 

## Root Cause
GitHub team references in CODEOWNERS files must include the organization name followed by a slash and then the team name. The previous syntax was missing the organization name prefix.

## Testing
After this change, GitHub should properly recognize the headstart-eng team as code owners and automatically request their review on PRs.