### PR TITLE
feat: add lboileau guestbook entry with GearRocketIcon

### DIFF
--- a/src/data/guestbook.json
+++ b/src/data/guestbook.json
@@ -1,5 +1,13 @@
 [
   {
+    "componentName": "GearRocketIcon",
+    "contributor": "lboileau",
+    "date": "2026-03-09T12:00:00.000Z",
+    "githubUsername": "lboileau",
+    "id": "gear-rocket-icon",
+    "message": "It's a brave new world. Are you ready?"
+  },
+  {
     "componentName": "RocketIcon",
     "contributor": "Mobo",
     "date": "2025-01-13T12:00:00.000Z",

--- a/src/icons/GearRocketIcon.tsx
+++ b/src/icons/GearRocketIcon.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { IconProps } from "../types";
+
+const GearRocketIcon: React.FC<IconProps> = ({ color = "currentColor", ...props }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill={color}
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        d="M9.13 5.07L10.26 2.15L13.74 2.15L14.87 5.07L17.74 3.81L20.19 6.26L18.93 9.13L21.85 10.26L21.85 13.74L18.93 14.87L20.19 17.74L17.74 20.19L14.87 18.93L13.74 21.85L10.26 21.85L9.13 18.93L6.26 20.19L3.81 17.74L5.07 14.87L2.15 13.74L2.15 10.26L5.07 9.13L3.81 6.26L6.26 3.81Z M17 12A5 5 0 1 1 7 12A5 5 0 1 1 17 12Z"
+      />
+      <path d="M12 7.5L10.5 10V14H13.5V10Z" />
+      <path d="M10.5 12L9 14.5L10.5 14Z" />
+      <path d="M13.5 12L15 14.5L13.5 14Z" />
+      <circle cx="12" cy="11" r="0.8" fill="white" opacity="0.8" />
+      <ellipse cx="12" cy="15.5" rx="1" ry="1.5" fill="#ff6b35" opacity="0.8" />
+    </svg>
+  );
+};
+
+export default GearRocketIcon;

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -15,6 +15,7 @@ import SpiralIcon from './SpiralIcon';
 import FireworksIcon from './FireworksIcon';
 import PaperAirplaneIcon from './PaperAirplaneIcon';
 import RocketIcon from './RocketIcon';
+import GearRocketIcon from './GearRocketIcon';
 
 const iconComponents: Record<string, React.FC<any>> = {
   StarIcon,
@@ -32,7 +33,8 @@ const iconComponents: Record<string, React.FC<any>> = {
   SpiralIcon,
   FireworksIcon,
   PaperAirplaneIcon,
-  RocketIcon
+  RocketIcon,
+  GearRocketIcon
 };
 
 export default iconComponents;


### PR DESCRIPTION
## Guestbook Entry

Adds a new guestbook entry for **lboileau**.

### Changes
- 🎨 New `GearRocketIcon` component — a gear ring with a rocket inside, complete with fins, porthole, and flame
- 📋 Registered `GearRocketIcon` in `src/icons/index.ts`
- 📝 Added entry to `src/data/guestbook.json` with message: *"It's a brave new world. Are you ready?"*